### PR TITLE
Migrate depreciated mcrypt to openssl.

### DIFF
--- a/DesEncryptor.php
+++ b/DesEncryptor.php
@@ -1,77 +1,59 @@
 <?php
 
-class DesEncryptor
-{
+class DesEncryptor {
+  protected $_key;
+  protected $_iv;
+  protected $_blocksize = 8;
+  protected $_encrypt;
+  protected $_cipher;
 
-    protected $_key;
-    protected $_iv;
-    protected $_blocksize = 8;
-    protected $_encrypt;
-    protected $_cipher;
+  /**
+   * Creates a symmetric Data Encryption Standard (DES) encryptor object
+   * with the specified key and initialization vector.
+   *
+   * @param $key
+   * @param $iv
+   * @param bool $encrypt
+   */
+  public function __construct($key, $iv, $encrypt = TRUE) {
+      $this->_key = $key;
+      $this->_iv = $iv;
+      $this->_encrypt = $encrypt;
+  }
 
-    /**
-     * Creates a symmetric Data Encryption Standard (DES) encryptor object
-     * with the specified key and initialization vector.
-     *
-     * @param $key
-     * @param $iv
-     * @param bool $encrypt
-     */
-    public function __construct($key, $iv, $encrypt = true)
-    {
-        $this->_key = $key;
-        $this->_iv = $iv;
-        $this->_encrypt = $encrypt;
-
-        $this->_cipher = mcrypt_module_open(MCRYPT_DES, '', MCRYPT_MODE_CBC, '');
-        mcrypt_generic_init($this->_cipher, $this->_key, $this->_iv);
+  /**
+   * Transforms the specified region of the specified byte array using PCKS7 padding.
+   * @param $text
+   * @return string
+   */
+  public function transformFinalBlock($text) {
+    if ($this->_encrypt) {
+      $padding = $this->_blocksize - strlen($text) % $this->_blocksize;
+      $text .= str_repeat(pack('C', $padding), $padding);
     }
 
-    public function __destruct()
-    {
-        mcrypt_generic_deinit($this->_cipher);
-        mcrypt_module_close($this->_cipher);
+    $text = $this->transformBlock($text);
+    
+    if (!$this->_encrypt) {
+      $aPadding = array_values(unpack('C', substr($text, -1)));
+      $padding = $aPadding[0];
+      $text = substr($text, 0, strlen($text) - $padding);
     }
+    
+    return $text;
+  }
 
-    /**
-     * Transforms the specified region of the specified byte array using PCKS7 padding.
-     * @param $text
-     * @return string
-     */
-    public function transformFinalBlock($text)
-    {
-        if ($this->_encrypt)
-        {
-            $padding = $this->_blocksize - strlen($text) % $this->_blocksize;
-            $text .= str_repeat(pack('C', $padding), $padding);
-        }
-
-        $text = $this->transformBlock($text);
-        
-        if (!$this->_encrypt)
-        {
-	    $aPadding = array_values(unpack('C', substr($text, -1)));
-	    $padding = $aPadding[0];
-            $text = substr($text, 0, strlen($text) - $padding);
-        }
-        
-        return $text;
+  /**
+   * Transforms the specified region of the specified byte array.
+   * @param $text
+   * @return string
+   */
+  public function transformBlock($text) {
+    if ($this->_encrypt) {
+      return openssl_encrypt($text, 'DES-CBC', $this->_key, OPENSSL_RAW_DATA, $this->_iv);
     }
-
-    /**
-     * Transforms the specified region of the specified byte array.
-     * @param $text
-     * @return string
-     */
-    public function transformBlock($text)
-    {
-        if ($this->_encrypt)
-        {
-            return mcrypt_generic($this->_cipher, $text);
-        }
-        else
-        {
-            return mdecrypt_generic($this->_cipher, $text);
-        }
+    else {
+      return openssl_decrypt($text, 'DES-CBC', $this->_key, OPENSSL_RAW_DATA, $this->_iv);
     }
+  }
 }

--- a/PbeWithMd5AndDes.php
+++ b/PbeWithMd5AndDes.php
@@ -1,28 +1,25 @@
 <?php
 
-class PbeWithMd5AndDes
-{
-   /**
-    * "Magic" keyword used by OpenSSL to put at the beginning of the encrypted
-    * bytes.
-    */
-    private static $MAGIC_SALTED_BYTES = "Salted__";
+class PbeWithMd5AndDes {
+ /**
+  * "Magic" keyword used by OpenSSL to put at the beginning of the encrypted
+  * bytes.
+  */
+  private static $MAGIC_SALTED_BYTES = "Salted__";
 
-    private static function _getCharRandonSalt($length = 16)
-    {
-        $salt = '';
-	for ($n = 0; $n < $length; $n++)
-	    $salt .= dechex(mt_rand(0, 0xF));
-  
-	return $salt;
+  private static function _getCharRandonSalt($length = 16) {
+    $salt = '';
+
+    for ($n = 0; $n < $length; $n++) {
+      $salt .= dechex(mt_rand(0, 0xF));
     }
 
-    public static function encrypt($data, $keystring, $salt = null, 
-		$iterationsMd5 = 1, $segments = 1)
-    {
-        $useRandomSalt = false;
-        if ($salt === null)
-	{
+    return $salt;
+  }
+
+  public static function encrypt($data, $keystring, $salt = null, $iterationsMd5 = 1, $segments = 1) {
+    $useRandomSalt = false;
+    if ($salt === null) {
 	    $salt = PbeWithMd5AndDes::_getCharRandonSalt();
 	    $useRandomSalt = true;
 	    /**
@@ -30,50 +27,43 @@ class PbeWithMd5AndDes
 	     *  needs to be set to 1 for our roundtrip to work.
 	     */
 	    $iterationsMd5 = 1;
-        }
-
-        $pkcsKeyGenerator = new PkcsKeyGenerator(
-			$keystring, $salt, $iterationsMd5, $segments);
-		
-        $encryptor = new DesEncryptor(
-			$pkcsKeyGenerator->getKey(), $pkcsKeyGenerator->getIv());
-		
-        $crypt = $encryptor->transformFinalBlock($data);
-
-	if ($useRandomSalt) {
-	  // add the magic keyword, salt informazionr and encrypted byte
-	  $crypt =  PbeWithMd5AndDes::$MAGIC_SALTED_BYTES .
-	    pack("H*", $salt) .
-	    $crypt;
-	}
-
-	// base64 encode so we can send it around as a string
-	return base64_encode($crypt);
     }
 
-    public static function decrypt($data, $keystring, $salt = null,
-		$iterationsMd5 = 1, $segments = 1)
-    {
-        if ($salt === null)
-	{
-	    // get the salt information from the input
-	    $salt = bin2hex(substr(base64_decode($data), 8, 8));
+    $pkcsKeyGenerator = new PkcsKeyGenerator($keystring, $salt, $iterationsMd5, $segments);
+	
+    $encryptor = new DesEncryptor($pkcsKeyGenerator->getKey(), $pkcsKeyGenerator->getIv());
 
-	    $data = base64_encode(substr(base64_decode($data), 16));
+    $crypt = $encryptor->transformFinalBlock($data);
 
-	    /**
-	     * Number of iterations -
-	     *  needs to be set to 1 for our roundtrip to work.
-	     */
-	    $iterationsMd5 = 1;
-	}
-
-        $pkcsKeyGenerator = new PkcsKeyGenerator(
-			$keystring, $salt, $iterationsMd5, $segments);
-
-        $encryptor = new DesEncryptor(
-			$pkcsKeyGenerator->getKey(), $pkcsKeyGenerator->getIv(), false);
-
-        return $encryptor->transformFinalBlock(base64_decode($data));
+    if ($useRandomSalt) {
+    // add the magic keyword, salt informazionr and encrypted byte
+      $crypt =  PbeWithMd5AndDes::$MAGIC_SALTED_BYTES . pack("H*", $salt) . $crypt;
     }
+
+    // base64 encode so we can send it around as a string
+    return base64_encode($crypt);
+  }
+
+  public static function decrypt($data, $keystring, $salt = null, $iterationsMd5 = 1, $segments = 1) {
+    if ($salt === null) {
+      // get the salt information from the input
+      $salt = bin2hex(substr(base64_decode($data), 8, 8));
+  
+      $data = base64_encode(substr(base64_decode($data), 16));
+  
+      /**
+       * Number of iterations -
+       *  needs to be set to 1 for our roundtrip to work.
+       */
+      $iterationsMd5 = 1;
+    }
+
+    $pkcsKeyGenerator = new PkcsKeyGenerator(
+		$keystring, $salt, $iterationsMd5, $segments);
+
+    $encryptor = new DesEncryptor(
+		$pkcsKeyGenerator->getKey(), $pkcsKeyGenerator->getIv(), false);
+
+    return $encryptor->transformFinalBlock(base64_decode($data));
+  }
 }

--- a/PkcsKeyGenerator.php
+++ b/PkcsKeyGenerator.php
@@ -1,55 +1,47 @@
 <?php
 
-class PkcsKeyGenerator 
-{
+class PkcsKeyGenerator {
 
     protected $_key;
     protected $_iv;
 
     /**
-	 * @return string
+     * @return string
      */
-    public function getKey()
-    {
-        return $this->_key;
+    public function getKey() {
+      return $this->_key;
     }
 
     /**
      * Gets the initialization vector.
-	 * @return string
+	   * @return string
      */
-    public function getIv()
-    {
-        return $this->_iv;
+    public function getIv() {
+      return $this->_iv;
     }
 
-    function __construct($keystring, $salt, $iterationsMd5, $segments)
-    {
-        $salt = pack('H*', $salt);
-        $keyMaterial = '';
-        $data = $keystring . $salt;
-        $result = '';
+    function __construct($keystring, $salt, $iterationsMd5, $segments) {
+      $salt = pack('H*', $salt);
+      $keyMaterial = '';
+      $data = $keystring . $salt;
+      $result = '';
 
-        for ($j = 0; $j < $segments; $j++)
-        {
-            if ($j == 0)
-            {
-                $result = $data;
-            }
-            else
-            {
-                $result .= $data;
-            }
-
-            for ($i = 0; $i < $iterationsMd5; $i++)
-            {
-                $result = md5($result, true);
-            }
-
-            $keyMaterial .= $result;
+      for ($j = 0; $j < $segments; $j++) {
+        if ($j == 0) {
+          $result = $data;
         }
+        else {
+          $result .= $data;
+        }
+        
+        for ($i = 0; $i < $iterationsMd5; $i++) {
+          $result = md5($result, true);
+        }
+        
+        $keyMaterial .= $result;
+      }
 
-        $this->_key = substr($keyMaterial, 0, 8);
-        $this->_iv = substr($keyMaterial, 8, 8);
+      $this->_key = substr($keyMaterial, 0, 8);
+      $this->_iv = substr($keyMaterial, 8, 8);
     }
 }


### PR DESCRIPTION
Managed to migrate the depreciated functions to use openssl, and this is good news because now PHP >= 7.2 is supported!

Tested out in a project and it seems to be working well so far.